### PR TITLE
Fix launchpads on distant worlds getting bad transforms

### DIFF
--- a/src/Core/StaticObjects/StaticInstance.cs
+++ b/src/Core/StaticObjects/StaticInstance.cs
@@ -94,9 +94,13 @@ namespace KerbalKonstructs.Core
             {
                 _mesh = value;
                 _mesh.name = "Mesh";
-                _mesh.transform.parent = gameObject.transform;
-                _mesh.transform.localPosition = Vector3.zero;
-                _mesh.transform.localRotation = Quaternion.identity;
+
+                if (_mesh != gameObject)
+                {
+                    _mesh.transform.parent = gameObject.transform;
+                    _mesh.transform.localPosition = Vector3.zero;
+                    _mesh.transform.localRotation = Quaternion.identity;
+                }
             }
         }
         internal GameObject wreck;

--- a/src/Core/StaticObjects/StaticInstance.cs
+++ b/src/Core/StaticObjects/StaticInstance.cs
@@ -95,8 +95,8 @@ namespace KerbalKonstructs.Core
                 _mesh = value;
                 _mesh.name = "Mesh";
                 _mesh.transform.parent = gameObject.transform;
-                _mesh.transform.position = transform.position;
-                _mesh.transform.rotation = transform.rotation;
+                _mesh.transform.localPosition = Vector3.zero;
+                _mesh.transform.localRotation = Quaternion.identity;
             }
         }
         internal GameObject wreck;


### PR DESCRIPTION
The old code looks equivalent, but it does a lot of transform math behind the scenes with VERY large numbers and the floating point error causes the object to appear in weird places.