### PR TITLE
Add compatibility with Shabby and Deferred

### DIFF
--- a/Unity/Shaders/Diffuse_Multiply_Random_Normal.shader
+++ b/Unity/Shaders/Diffuse_Multiply_Random_Normal.shader
@@ -22,6 +22,13 @@ Shader "KK/Diffuse_Multiply_Random"
 		ZWrite On
 		ZTest LEqual
 
+		Stencil
+		{
+			Ref 4
+			Comp Always
+			Pass Replace
+		}  
+
         CGPROGRAM
         // Upgrade NOTE: excluded shader from OpenGL ES 2.0 because it uses non-square matrices
         #pragma exclude_renderers gles

--- a/Unity/Shaders/Diffuse_Multiply_Random_Normal.shader
+++ b/Unity/Shaders/Diffuse_Multiply_Random_Normal.shader
@@ -21,15 +21,14 @@ Shader "KK/Diffuse_Multiply_Random"
         LOD 200
 		ZWrite On
 		ZTest LEqual
-		Blend SrcAlpha OneMinusSrcAlpha
 
         CGPROGRAM
         // Upgrade NOTE: excluded shader from OpenGL ES 2.0 because it uses non-square matrices
         #pragma exclude_renderers gles
-        // Physically based Standard lighting model, and enable shadows on all light types
+        
+		// Physically based Standard lighting model, and enable shadows on all light types
         #pragma surface surf BlinnPhong fullforwardshadows nofog
  
-        // Use shader model 3.0 target, to get nicer looking lighting
         #pragma target 3.0
 
         #include "KSP-include.cginc"
@@ -111,9 +110,6 @@ Shader "KK/Diffuse_Multiply_Random"
 			//fixed4 glow = tex2D(_Emissive, (IN.uv_MainTex));
 			//o.Emission = glow.rgb * glow.aaa * _EmissiveColor.rgb * _EmissiveColor.aaa + stockEmit(IN.viewDir, normal, _RimColor, _RimFalloff, _TemperatureColor) * _Opacity;
 			o.Emission = stockEmit(IN.viewDir, normal, _RimColor, _RimFalloff, _TemperatureColor) * _Opacity;
-
-			//controlled directly by shader property
-			o.Alpha = _Opacity;
 
 
 			//apply the standard shader param multipliers to the sampled/computed values.

--- a/Unity/Shaders/Ground_Multi_NoUV_Normal.shader
+++ b/Unity/Shaders/Ground_Multi_NoUV_Normal.shader
@@ -48,6 +48,13 @@ Shader "KK/Ground_Multi_NoUV"
 		ZWrite On
 		ZTest LEqual
 
+		Stencil
+		{
+			Ref 4
+			Comp Always
+			Pass Replace
+		}  
+
         CGPROGRAM
         // Upgrade NOTE: excluded shader from OpenGL ES 2.0 because it uses non-square matrices
         #pragma exclude_renderers gles

--- a/Unity/Shaders/Ground_Multi_NoUV_Normal.shader
+++ b/Unity/Shaders/Ground_Multi_NoUV_Normal.shader
@@ -47,7 +47,6 @@ Shader "KK/Ground_Multi_NoUV"
         LOD 200
 		ZWrite On
 		ZTest LEqual
-		Blend SrcAlpha OneMinusSrcAlpha
 
         CGPROGRAM
         // Upgrade NOTE: excluded shader from OpenGL ES 2.0 because it uses non-square matrices
@@ -292,9 +291,6 @@ Shader "KK/Ground_Multi_NoUV"
 			//fixed4 glow = tex2D(_Emissive, (IN.uv_MainTex));
 			//o.Emission = glow.rgb * glow.aaa * _EmissiveColor.rgb * _EmissiveColor.aaa + stockEmit(IN.viewDir, normal, _RimColor, _RimFalloff, _TemperatureColor) * _Opacity;
 			o.Emission = stockEmit(IN.viewDir, normal, _RimColor, _RimFalloff, _TemperatureColor) * _Opacity;
-
-			//controlled directly by shader property
-			o.Alpha = _Opacity;
 
 
 			//apply the standard shader param multipliers to the sampled/computed values.

--- a/Unity/Shaders/NormalFromTexture.shader
+++ b/Unity/Shaders/NormalFromTexture.shader
@@ -12,6 +12,13 @@
         Tags { "RenderType"="Opaque" }
         LOD 100
 
+        Stencil
+        {
+            Ref 4
+            Comp Always
+            Pass Replace
+        }  
+
         Pass
         {
             CGPROGRAM

--- a/src/Core/StaticObjects/StaticModules/AdvTextures/AdvTextures.cs
+++ b/src/Core/StaticObjects/StaticModules/AdvTextures/AdvTextures.cs
@@ -226,13 +226,14 @@ namespace KerbalKonstructs
 
         internal void ReplaceShader(MeshRenderer renderer, string newShaderName)
         {
-            if (!KKGraphics.HasShader(newShaderName))
+            Shader newShader = KKGraphics.GetShader(newShaderName);
+
+            if (newShader == null)
             {
                 Log.UserError("No Shader like this found: " + newShaderName);
                 return;
             }
 
-            Shader newShader = KKGraphics.GetShader(newShaderName);
             renderer.material.shader = newShader;
             //Log.Normal("Applied Shader: " + newShader.name);
 


### PR DESCRIPTION
- Change shader loading logic to first look in own assetbundles, then use Shader.Find which can be overridden by Shabby

- Remove alpha blending from two shaders to make them comaptible with deferred rendering (shaders in question seem to be only used on Opaque statics from what I can tell)

- Add stencil values used by Deferred (https://github.com/LGhassen/Deferred?tab=readme-ov-file#stencil-buffer-usage)

Requires a shader bundle recompilation