### PR TITLE
Fix shader loading

### DIFF
--- a/src/Utilities/KKGraphics.cs
+++ b/src/Utilities/KKGraphics.cs
@@ -67,7 +67,7 @@ namespace KerbalKonstructs
                     bundleFileName = "kkshaders.osx";
                     break;
                 case RuntimePlatform.LinuxPlayer:
-                    bundleFileName = "kkshaders.osx";
+                    bundleFileName = "kkshaders.linux";
                     break;
                 default:
                     bundleFileName = "kkshaders.windows";
@@ -106,8 +106,10 @@ namespace KerbalKonstructs
         private static void LoadAndRegisterShader(AssetBundle bundle , string shaderName)
         {
             Shader newShader = bundle.LoadAsset<Shader>(shaderName);
+            if (newShader == null) { return; } // This file is not a shader; ignore it.
+
             GameObject.DontDestroyOnLoad(newShader);
-            if (newShader == null || !newShader.isSupported)
+            if (!newShader.isSupported)
             {
                 Log.Error("could not load shader: " + shaderName + " from: " + bundle.name);
             }


### PR DESCRIPTION
Fixes two issues:
- Load the Linux shader assetbundle instead of the OSX version on Linux
- The new assetbundle from #24 contain files other than the shaders - both intended (the new `.cginc` files), and a few unintended ones (in a folder named b9, there are `.obj` and `.mat` files). For the former, fix the exception that occured when trying to load those files as shaders. For the latter, the assetbundles should be recompiled without those files.