### PR TITLE
Bug fixes

### DIFF
--- a/src/Core/StaticObjects/StaticInstance.cs
+++ b/src/Core/StaticObjects/StaticInstance.cs
@@ -190,7 +190,7 @@ namespace KerbalKonstructs.Core
             RefLongitude = (float)(CelestialBody.GetLatitudeAndLongitude(gameObject.transform.position).y);
             RadialPosition = radialPosition;
 
-            gameObject.transform.localScale = origScale * ModelScale;
+            gameObject.transform.localScale = origScale != Vector3.zero ? origScale * ModelScale : Vector3.one * ModelScale;
 
             RelativePosition = gameObject.transform.localPosition;
             Orientation = gameObject.transform.localEulerAngles;

--- a/src/Core/StaticObjects/StaticModules/Destructable/Destructable.cs
+++ b/src/Core/StaticObjects/StaticModules/Destructable/Destructable.cs
@@ -90,7 +90,24 @@ namespace KerbalKonstructs
 
             float wrecksize = 65f;
 
-            float min = Math.Min(staticBounds.size.x, staticBounds.size.z);
+            float min = 1;
+            if (staticBounds.size.x != 0 && staticBounds.size.z != 0)
+            {
+                min = Math.Min(staticBounds.size.x, staticBounds.size.z);
+            }
+            else if (staticBounds.size.x == 0 && staticBounds.size.z != 0)
+            {
+                min = staticBounds.size.z;
+            }
+            else if (staticBounds.size.x != 0 && staticBounds.size.z == 0)
+            {
+                min = staticBounds.size.x;
+            }
+            else
+            {
+                min = 1;
+            }
+
             float max = Math.Max(staticBounds.size.x, staticBounds.size.z);
 
             float scale = min / wrecksize;


### PR DESCRIPTION
Fixed a memory leak in the destructable.cs (staticbounds min can become 0 causing an infinite loop) and added an additional check to the StaticInstance.Update method to ensure that the origscale is not 0.