### PR TITLE
Allow custom editor windows

### DIFF
--- a/src/Core/StaticGroup/GroupCenter.cs
+++ b/src/Core/StaticGroup/GroupCenter.cs
@@ -382,7 +382,7 @@ namespace KerbalKonstructs.Core
         /// Writes out the GroupCenter config
         /// </summary>
         /// <param name="instance"></param>
-        internal void Save()
+        public void Save()
         {
             if (isBuiltIn)
             {

--- a/src/Editor/GroupEditor/GroupEditor.cs
+++ b/src/Editor/GroupEditor/GroupEditor.cs
@@ -8,7 +8,7 @@ namespace KerbalKonstructs.UI
     public class GroupEditor : KKWindow
     {
 
-        private static GroupEditor _instance = null;
+        protected static GroupEditor _instance = null;
         public static GroupEditor instance
         {
             get
@@ -23,26 +23,26 @@ namespace KerbalKonstructs.UI
         }
 
         #region Variable Declarations
-        private List<Transform> transformList = new List<Transform>();
-        private CelestialBody body;
-        private bool showNameField = false;
+        protected List<Transform> transformList = new List<Transform>();
+        protected CelestialBody body;
+        protected bool showNameField = false;
 
-        private string newGroupName = "";
+        protected string newGroupName = "";
 
-        internal Boolean foldedIn = false;
-        internal Boolean doneFold = false;
+        public Boolean foldedIn = false;
+        public Boolean doneFold = false;
 
 
 
         #region Texture Definitions
         // Texture definitions
-        internal Texture tHorizontalSep = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/horizontalsep2", false);
-        internal Texture tCopyPos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/copypos", false);
-        internal Texture tPastePos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/pastepos", false);
-        internal Texture tSnap = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/snapto", false);
-        internal Texture tFoldOut = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldin", false);
-        internal Texture tFoldIn = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
-        internal Texture tFolded = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
+        public Texture tHorizontalSep = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/horizontalsep2", false);
+        public Texture tCopyPos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/copypos", false);
+        public Texture tPastePos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/pastepos", false);
+        public Texture tSnap = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/snapto", false);
+        public Texture tFoldOut = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldin", false);
+        public Texture tFoldIn = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
+        public Texture tFolded = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
 
 
         #endregion
@@ -54,7 +54,7 @@ namespace KerbalKonstructs.UI
 
         #region GUI Windows
         // GUI Windows
-        internal Rect toolRect = new Rect(300, 35, 330, 350);
+        public Rect toolRect = new Rect(300, 35, 330, 350);
 
         #endregion
 
@@ -62,33 +62,33 @@ namespace KerbalKonstructs.UI
         #region Holders
         // Holders
 
-        internal static GroupCenter selectedGroup = null;
-        internal GroupCenter selectedObjectPrevious = null;
+        public static GroupCenter selectedGroup = null;
+        public GroupCenter selectedObjectPrevious = null;
 
-        internal string refLat, refLng, headingStr;
+        public string refLat, refLng, headingStr;
 
         //internal static String facType = "None";
         //internal static String sGroup = "Ungrouped";
-        private float increment = 1f;
+        protected float increment = 1f;
 
 
-        private VectorRenderer upVR = new VectorRenderer();
-        private VectorRenderer fwdVR = new VectorRenderer();
-        private VectorRenderer rightVR = new VectorRenderer();
+        protected VectorRenderer upVR = new VectorRenderer();
+        protected VectorRenderer fwdVR = new VectorRenderer();
+        protected VectorRenderer rightVR = new VectorRenderer();
 
-        private VectorRenderer northVR = new VectorRenderer();
-        private VectorRenderer eastVR = new VectorRenderer();
-
-
-        private static Space referenceSystem = Space.Self;
-
-        private static Vector3d position = Vector3d.zero;
-        private Vector3d savedReferenceVector = Vector3d.zero;
+        protected VectorRenderer northVR = new VectorRenderer();
+        protected VectorRenderer eastVR = new VectorRenderer();
 
 
-        private static Vector3 startPosition = Vector3.zero;
+        protected static Space referenceSystem = Space.Self;
 
-        internal static float maxEditorRange = 250;
+        protected static Vector3d position = Vector3d.zero;
+        protected Vector3d savedReferenceVector = Vector3d.zero;
+
+
+        protected static Vector3 startPosition = Vector3.zero;
+
+        public static float maxEditorRange = 250;
 
         #endregion
 
@@ -129,7 +129,7 @@ namespace KerbalKonstructs.UI
         /// Wrapper to draw editors
         /// </summary>
         /// <param name="groupCenter"></param>
-        internal void drawEditor(GroupCenter groupCenter)
+        public void drawEditor(GroupCenter groupCenter)
         {
             if (groupCenter == null)
             {
@@ -163,7 +163,7 @@ namespace KerbalKonstructs.UI
         /// Instance Editor window
         /// </summary>
         /// <param name="windowID"></param>
-        void GroupEditorWindow(int windowID)
+        protected virtual void GroupEditorWindow(int windowID)
         {
 
             UpdateVectors();
@@ -533,7 +533,7 @@ namespace KerbalKonstructs.UI
         #region Utility Functions
 
 
-        internal void DeleteGroupCenter()
+        public void DeleteGroupCenter()
         {
             if (selectedObjectPrevious == selectedGroup)
             {
@@ -570,7 +570,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// the starting position of direction vectors (a bit right and up from the Objects position)
         /// </summary>
-        private Vector3 vectorDrawPosition
+        protected Vector3 vectorDrawPosition
         {
             get
             {
@@ -605,7 +605,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// gives a vector to the east
         /// </summary>
-        private Vector3 eastVector
+        protected Vector3 eastVector
         {
             get
             {
@@ -616,7 +616,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// vector to north
         /// </summary>
-        private Vector3 northVector
+        protected Vector3 northVector
         {
             get
             {
@@ -625,7 +625,7 @@ namespace KerbalKonstructs.UI
             }
         }
 
-        private Vector3 upVector
+        protected Vector3 upVector
         {
             get
             {
@@ -637,7 +637,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// Sets the vectors active and updates thier position and directions
         /// </summary>
-        private void UpdateVectors()
+        protected void UpdateVectors()
         {
             if (selectedGroup == null)
             {
@@ -687,7 +687,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// creates the Vectors for later display
         /// </summary>
-        private void SetupVectors()
+        protected void SetupVectors()
         {
             // draw vectors
             fwdVR.Color = new Color(0, 0, 1);
@@ -730,7 +730,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// stops the drawing of the vectors
         /// </summary>
-        private void CloseVectors()
+        protected void CloseVectors()
         {
             northVR.SetShow(false);
             eastVR.SetShow(false);
@@ -744,7 +744,7 @@ namespace KerbalKonstructs.UI
         /// </summary>
         /// <param name="north"></param>
         /// <param name="east"></param>
-        internal void Setlatlng(double north, double east)
+        public void Setlatlng(double north, double east)
         {
             body = Planetarium.fetch.CurrentMainBody;
             double latOffset = north / (body.Radius * KKMath.deg2rad);
@@ -764,7 +764,7 @@ namespace KerbalKonstructs.UI
         /// changes the rotation by a defined amount
         /// </summary>
         /// <param name="increment"></param>
-        internal void SetRotation(float increment)
+        public void SetRotation(float increment)
         {
             selectedGroup.RotationAngle += (float)increment;
             selectedGroup.RotationAngle = (360f + selectedGroup.RotationAngle) % 360f;
@@ -776,7 +776,7 @@ namespace KerbalKonstructs.UI
         /// Updates the StaticObject position with a new transform
         /// </summary>
         /// <param name="direction"></param>
-        internal void SetTransform(Vector3 direction)
+        public void SetTransform(Vector3 direction)
         {
             // adjust transform for scaled models
             direction = direction / selectedGroup.ModelScale;
@@ -789,7 +789,7 @@ namespace KerbalKonstructs.UI
         }
 
 
-        internal void OnMoveCallBack(Vector3 vector)
+        public void OnMoveCallBack(Vector3 vector)
         {
             // Log.Normal("OnMove: " + vector.ToString());
             //moveGizmo.transform.position += 3* vector;
@@ -805,13 +805,13 @@ namespace KerbalKonstructs.UI
 
         }
 
-        internal void WhenMovedCallBack(Vector3 vector)
+        public void WhenMovedCallBack(Vector3 vector)
         {
             ApplySettings();
             //Log.Normal("WhenMoved: " + vector.ToString());
         }
 
-        internal void UpdateMoveGizmo()
+        public void UpdateMoveGizmo()
         {
             EditorGizmo.CloseGizmo();
             EditorGizmo.SetupMoveGizmo(selectedGroup.gameObject, Quaternion.identity, OnMoveCallBack, WhenMovedCallBack);
@@ -819,7 +819,7 @@ namespace KerbalKonstructs.UI
 
 
 
-        internal void ApplyInputStrings()
+        public void ApplyInputStrings()
         {
 
             selectedGroup.RefLatitude = double.Parse(refLat);
@@ -845,7 +845,7 @@ namespace KerbalKonstructs.UI
         }
 
 
-        internal void UpdateStrings()
+        public void UpdateStrings()
         {
             refLat = Math.Round(selectedGroup.RefLatitude, 4).ToString();
             refLng = Math.Round(selectedGroup.RefLongitude, 4).ToString();
@@ -857,7 +857,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// Saves the current instance settings to the object.
         /// </summary>
-        internal void ApplySettings()
+        public void ApplySettings()
         {
             selectedGroup.Update();
             UpdateStrings();
@@ -865,7 +865,7 @@ namespace KerbalKonstructs.UI
         }
 
 
-        internal void CheckEditorKeys()
+        public void CheckEditorKeys()
         {
             if (selectedGroup != null)
             {

--- a/src/Editor/InstanceEditor/EditorGUI.cs
+++ b/src/Editor/InstanceEditor/EditorGUI.cs
@@ -10,17 +10,17 @@ namespace KerbalKonstructs.UI
     public class EditorGUI : KKWindow
     {
 
-        private enum Reference
+        protected enum Reference
         {
             Model,
             Center
         }
 
 
-        internal static float windowWidth = 330;
-        internal static float windowHeight = 750;
+        public static float windowWidth = 330;
+        public static float windowHeight = 750;
 
-        private static EditorGUI _instance = null;
+        protected static EditorGUI _instance = null;
         public static EditorGUI instance
         {
             get
@@ -35,19 +35,19 @@ namespace KerbalKonstructs.UI
         }
 
         #region Variable Declarations
-        private List<Transform> transformList = new List<Transform>();
-        private CelestialBody body;
+        protected List<Transform> transformList = new List<Transform>();
+        protected CelestialBody body;
 
 
         #region Texture Definitions
         // Texture definitions
-        internal Texture tHorizontalSep = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/horizontalsep2", false);
-        internal Texture tCopyPos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/copypos", false);
-        internal Texture tPastePos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/pastepos", false);
-        internal Texture tSnap = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/snapto", false);
-        internal Texture tFoldOut = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldin", false);
-        internal Texture tFoldIn = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
-        internal Texture tFolded = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
+        public Texture tHorizontalSep = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/horizontalsep2", false);
+        public Texture tCopyPos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/copypos", false);
+        public Texture tPastePos = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/pastepos", false);
+        public Texture tSnap = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/snapto", false);
+        public Texture tFoldOut = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldin", false);
+        public Texture tFoldIn = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
+        public Texture tFolded = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/foldout", false);
 
 
         #endregion
@@ -55,22 +55,22 @@ namespace KerbalKonstructs.UI
         #region Switches
         // Switches
         public Boolean enableColliders = false;
-        internal Boolean enableColliders2 = false;
+        public Boolean enableColliders2 = false;
         //internal static bool isScanable = false;
 
         //public static Boolean editingLaunchSite = false;
 
         //   public static Boolean editingFacility = false;
 
-        internal Boolean SnapRotateMode = false;
-        internal static bool grasColorEnabled = false;
-        internal static bool grassColor2Enabled = false;
+        public Boolean SnapRotateMode = false;
+        public static bool grasColorEnabled = false;
+        public static bool grassColor2Enabled = false;
 
         #endregion
 
         #region GUI Windows
         // GUI Windows
-        internal static Rect toolRect = new Rect(1200, 60, windowWidth, windowHeight);
+        public static Rect toolRect = new Rect(1200, 60, windowWidth, windowHeight);
 
         #endregion
 
@@ -78,45 +78,45 @@ namespace KerbalKonstructs.UI
         #region Holders
         // Holders
 
-        internal static StaticInstance selectedInstance = null;
-        internal StaticInstance selectedObjectPrevious = null;
-        internal static KKLaunchSite lTargetSite = null;
+        public static StaticInstance selectedInstance = null;
+        public StaticInstance selectedObjectPrevious = null;
+        public static KKLaunchSite lTargetSite = null;
 
         //internal static String facType = "None";
         //internal static String sGroup = "Ungrouped";
-        private float increment = 1f;
+        protected float increment = 1f;
 
-        private VectorRenderer upVR = new VectorRenderer();
-        private VectorRenderer fwdVR = new VectorRenderer();
-        private VectorRenderer rightVR = new VectorRenderer();
+        protected VectorRenderer upVR = new VectorRenderer();
+        protected VectorRenderer fwdVR = new VectorRenderer();
+        protected VectorRenderer rightVR = new VectorRenderer();
 
-        private Vector3d savedPosition;
-        private bool savedpos = false;
+        protected Vector3d savedPosition;
+        protected bool savedpos = false;
 
-        private static Reference referenceSystem = Reference.Center;
+        protected static Reference referenceSystem = Reference.Center;
 
-        private Vector3d savedRotation = Vector3d.zero;
+        protected Vector3d savedRotation = Vector3d.zero;
 
-        private string incrementStr, altStr, oriXStr, oriYStr, oriZStr, posXStr, posYStr, posZStr;
+        protected string incrementStr, altStr, oriXStr, oriYStr, oriZStr, posXStr, posYStr, posZStr;
 
-        private float fTempWidth = 80f;
+        protected float fTempWidth = 80f;
 
-        private static double cameraDistance;
+        protected static double cameraDistance;
 
-        private static Vector3 origPosition, origRotation;
-        private static GroupCenter origCenter;
-        private static float origScale;
+        protected static Vector3 origPosition, origRotation;
+        protected static GroupCenter origCenter;
+        protected static float origScale;
 
-        private static Vector3 northVector;
-        private static Vector3 eastVector;
-        private static Vector3 forwardVector;
+        protected static Vector3 northVector;
+        protected static Vector3 eastVector;
+        protected static Vector3 forwardVector;
 
-        private static Vector3 movement;
-        private static Vector3 localMovement;
-        private static Vector3 origLocalPosition;
+        protected static Vector3 movement;
+        protected static Vector3 localMovement;
+        protected static Vector3 origLocalPosition;
 
-        private static GrasColor grassMod = null;
-        private static GrassColor2 grassMod2 = null;
+        protected static GrasColor grassMod = null;
+        protected static GrassColor2 grassMod2 = null;
 
 
         #endregion
@@ -200,7 +200,7 @@ namespace KerbalKonstructs.UI
         /// Instance Editor window
         /// </summary>
         /// <param name="windowID"></param>
-        void InstanceEditorWindow(int windowID)
+        public virtual void InstanceEditorWindow(int windowID)
         {
 
             UpdateVectors();
@@ -820,7 +820,7 @@ namespace KerbalKonstructs.UI
         #region Utility Functions
 
 
-        internal void DeleteInstance()
+        public void DeleteInstance()
         {
             if (StaticsEditorGUI.instance.snapTargetInstance == selectedInstance)
                 StaticsEditorGUI.instance.snapTargetInstance = null;
@@ -853,7 +853,7 @@ namespace KerbalKonstructs.UI
         /// <param name="vPosition"></param>
         /// <param name="fAngle"></param>
         /// <returns></returns>
-        internal void SpawnInstance(StaticModel model, GroupCenter groupCenter, Vector3 position, Vector3 rotation)
+        public void SpawnInstance(StaticModel model, GroupCenter groupCenter, Vector3 position, Vector3 rotation)
         {
             StaticInstance instance = new StaticInstance();
             instance.model = model;
@@ -896,7 +896,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// the starting position of direction vectors (a bit right and up from the Objects position)
         /// </summary>
-        private Vector3 vectorDrawPosition
+        protected Vector3 vectorDrawPosition
         {
             get
             {
@@ -905,7 +905,7 @@ namespace KerbalKonstructs.UI
             }
         }
 
-        private string GetHeading()
+        protected string GetHeading()
         {
             float angle = Vector3.Angle(Vector3.ProjectOnPlane(selectedInstance.transform.forward, selectedInstance.transform.up), selectedInstance.transform.parent.forward);
 
@@ -921,7 +921,7 @@ namespace KerbalKonstructs.UI
         }
 
 
-        private Vector3 upVector
+        protected Vector3 upVector
         {
             get
             {
@@ -933,7 +933,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// Sets the vectors active and updates thier position and directions
         /// </summary>
-        private void UpdateVectors()
+        protected void UpdateVectors()
         {
             if (selectedInstance == null)
             {
@@ -990,7 +990,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// creates the Vectors for later display
         /// </summary>
-        private void SetupVectors()
+        protected void SetupVectors()
         {
             cameraDistance = Vector3.Distance(selectedInstance.position, FlightCamera.fetch.transform.position) / 4;
 
@@ -1024,7 +1024,7 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// stops the drawing of the vectors
         /// </summary>
-        private void CloseVectors()
+        protected void CloseVectors()
         {
 
             fwdVR.SetShow(false);
@@ -1033,7 +1033,7 @@ namespace KerbalKonstructs.UI
 
         }
 
-        private void SetupGizmo()
+        protected void SetupGizmo()
         {
             origLocalPosition = selectedInstance.transform.localPosition;
             if (referenceSystem == Reference.Center)
@@ -1046,18 +1046,18 @@ namespace KerbalKonstructs.UI
             }
         }
 
-        private void CloseGizmo()
+        protected void CloseGizmo()
         {
             EditorGizmo.CloseGizmo();
         }
 
-        private void UpdateGizmo()
+        protected void UpdateGizmo()
         {
             EditorGizmo.CloseGizmo();
             SetupGizmo();
         }
 
-        internal void OnMoveCB(Vector3 vector)
+        public void OnMoveCB(Vector3 vector)
         {
             // Log.Normal("OnMove: " + vector.ToString());
             //moveGizmo.transform.position += 3* vector;
@@ -1065,7 +1065,7 @@ namespace KerbalKonstructs.UI
             //selectedInstance.gameObject.transform.localPosition += selectedInstance.groupCenter.gameObject.transform.InverseTransformDirection(vector);
         }
 
-        internal void WhenMovedCB(Vector3 vector)
+        public void WhenMovedCB(Vector3 vector)
         {
             //Log.Normal("WhenMoved: " + vector.ToString());
             selectedInstance.transform.localPosition = origLocalPosition + selectedInstance.groupCenter.gameObject.transform.InverseTransformDirection(vector);
@@ -1073,7 +1073,7 @@ namespace KerbalKonstructs.UI
         }
 
 
-        internal void SetupFields()
+        public void SetupFields()
         {
             incrementStr = increment.ToString();
             altStr = selectedInstance.CelestialBody.GetAltitude(selectedInstance.transform.position).ToString();
@@ -1088,7 +1088,7 @@ namespace KerbalKonstructs.UI
 
         }
 
-        internal void ApplyInputStrings()
+        public void ApplyInputStrings()
         {
             increment = float.Parse(incrementStr);
 
@@ -1106,7 +1106,7 @@ namespace KerbalKonstructs.UI
         /// changes the rotation by a defined amount
         /// </summary>
         /// <param name="increment"></param>
-        internal void SetRotation(Vector3 axis, float increment)
+        public void SetRotation(Vector3 axis, float increment)
         {
             selectedInstance.transform.Rotate(axis, increment);
             ApplySettings();
@@ -1117,7 +1117,7 @@ namespace KerbalKonstructs.UI
         /// Updates the StaticObject position with a new transform
         /// </summary>
         /// <param name="direction"></param>
-        internal void SetTransform(Vector3 direction)
+        public void SetTransform(Vector3 direction)
         {
             direction = direction / selectedInstance.ModelScale;
             //selectedInstance.gameObject.transform.Translate(direction, Space.Self);
@@ -1153,7 +1153,7 @@ namespace KerbalKonstructs.UI
         /// CallBack Functions for Group Selection
         /// </summary>
         /// <param name="newGroup"></param>
-        internal void SetGroup(GroupCenter newGroup)
+        public void SetGroup(GroupCenter newGroup)
         {
             Log.Normal("setting Group from " + selectedInstance.groupCenter.Group + " to " + newGroup.Group);
             StaticDatabase.ChangeGroup(selectedInstance, newGroup);
@@ -1164,14 +1164,14 @@ namespace KerbalKonstructs.UI
         /// <summary>
         /// Saves the current instance settings to the object.
         /// </summary>
-        internal void ApplySettings()
+        public void ApplySettings()
         {
             selectedInstance.Update();
             SetupFields();
             UpdateGizmo();
         }
 
-        internal double instanceHeading
+        public double instanceHeading
         {
             get
             {
@@ -1191,7 +1191,7 @@ namespace KerbalKonstructs.UI
                 return Math.Round(heading, 2);
             }
         }
-        internal void CheckEditorKeys()
+        public void CheckEditorKeys()
         {
             if (selectedInstance != null)
             {

--- a/src/ExternalAPI/API.cs
+++ b/src/ExternalAPI/API.cs
@@ -258,6 +258,22 @@ namespace KerbalKonstructs
             return false;
         }
 
+        public static GroupCenter GetGroupCenter(string name, string bodyName = null)
+        {
+            if (bodyName == null)
+            {
+                bodyName = StaticDatabase.lastActiveBody.name;
+            }   
+
+            string groupNameB = $"{bodyName}_{name}";
+            if (StaticDatabase.HasGroupCenter(groupNameB))
+            {
+                return StaticDatabase.GetGroupCenter(groupNameB);
+            }
+            Log.UserWarning($"API:GetGroupCenter: group with name {name} does not exists.");
+            return null;
+        }
+
         /// <summary>
         /// Copies all statics from a group to another group
         /// </summary>

--- a/src/UI/UIMain.cs
+++ b/src/UI/UIMain.cs
@@ -41,11 +41,11 @@ namespace KerbalKonstructs.UI
         public static Texture tFavesOn = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/mapFavouritesOn", false);
         public static Texture tFavesOff = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/mapFavouritesOff", false);
 
-        internal static Texture iconWorld = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/world", false);
-        internal static Texture iconCubes = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/cubes", false);
-        internal static Texture iconTerrain = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/terrain", false);
+        public static Texture iconWorld = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/world", false);
+        public static Texture iconCubes = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/cubes", false);
+        public static Texture iconTerrain = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/terrain", false);
 
-        internal static Texture iconRecoveryBase = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/recoveryBase", false);
+        public static Texture iconRecoveryBase = GameDatabase.Instance.GetTexture("KerbalKonstructs/Assets/recoveryBase", false);
 
         public static Texture tIconClosed;
         public static Texture tIconOpen;


### PR DESCRIPTION
I changed a bunch of access modifiers so I can overwrite the group editor window and remove the delete and normal close buttons because both are things that I don't want a user can do when creating facilities with my KC mod.

I did the same changes to the static editor window although I currently don't need it.


I plan to release the KC mod within the next two weeks and there may be a few minor changes to KK left so I would highly appreciate it if I could get a way to contact one of the KK maintainers a few days before the release to then merge this pr and create a new KK version.