### PR TITLE
Scale fRadarRadius with body radius, check fRadarRadius for tooltip display

### DIFF
--- a/src/Modules/MapIcons/MapIconDraw.cs
+++ b/src/Modules/MapIcons/MapIconDraw.cs
@@ -43,6 +43,8 @@ namespace KerbalKonstructs.Modules
 
         private bool cscIsOpen = false;
 
+        private const float KerbinRadius = 600000f;
+
         Rect screenRect;
 
         public override void Draw()
@@ -155,7 +157,7 @@ namespace KerbalKonstructs.Modules
                 Rect screenRect6 = new Rect((pos.x - 8), (Screen.height - pos.y) - 8, 16, 16);
                 // Distance between camera and spawnpoint sort of
                 float fPosZ = pos.z;
-                float fRadarRadius = 12800 / fPosZ;
+                float fRadarRadius = (12800 / fPosZ) * ((float)groundStation.CelestialBody.Radius / KerbinRadius);
 
                 if (fRadarRadius > 15) GUI.DrawTexture(screenRect6, UIMain.TrackingStationIcon, ScaleMode.ScaleToFit, true);
 
@@ -235,8 +237,7 @@ namespace KerbalKonstructs.Modules
                 // Distance between camera and spawnpoint sort of
                 float fPosZ = lsPosition.z;
 
-                float fRadarRadius = 12800 / fPosZ;
-                float fRadarOffset = fRadarRadius / 2;
+                float fRadarRadius = (12800 / fPosZ) * ((float)launchSite.body.Radius / KerbinRadius);
 
 
                 if (launchSite.icon != null)
@@ -270,7 +271,7 @@ namespace KerbalKonstructs.Modules
                 }
 
                 // Tooltip
-                if (!displayingTooltip && screenRect.Contains(Event.current.mousePosition))
+                if (!displayingTooltip && screenRect.Contains(Event.current.mousePosition) && fRadarRadius > 15)
                 {
                     //Only display one tooltip at a time
                     string sToolTip = "";
@@ -330,7 +331,7 @@ namespace KerbalKonstructs.Modules
                 Rect screenRect6 = new Rect((pos.x - 8), (Screen.height - pos.y) - 8, 16, 16);
                 // Distance between camera and spawnpoint sort of
                 float fPosZ = pos.z;
-                float fRadarRadius = 12800 / fPosZ;
+                float fRadarRadius = (12800 / fPosZ) * ((float)body.Radius / KerbinRadius);
 
                 if (fRadarRadius > 15)
                 {


### PR DESCRIPTION
fRadarRadius was not scaling with the body radius, which made `(fRadarRadius > 15)` more difficult to achieve for larger bodies. This made numerous things never show up with larger bodies, notably the icons usually seen in the Map View. ![image](https://github.com/user-attachments/assets/05c8bc79-919c-45b8-a39d-ee2479653b75)

Compare the KK icons on Earth before and after this change:
![image](https://github.com/user-attachments/assets/3f06e9a8-3a2a-414c-a5ba-f07503a6109e) ![image](https://github.com/user-attachments/assets/07c15897-b31e-4673-8a9e-6f857886490a) (fRadarRadius at max zoom in tracking station, notice how its below 15)


![image](https://github.com/user-attachments/assets/39dbce6e-099d-444d-a219-03147a4d9b4d) ![image](https://github.com/user-attachments/assets/7d343331-4ba1-4170-97b5-adfc70b7f23f) (fRadarRadius at max zoom in tracking station)




This PR also hides the tooltip (and the ability to open the KK menu accidentally) when `(fRadarRadius > 15)` is not true, which fixes https://github.com/KSP-RO/Kerbal-Konstructs/issues/39. Credit to @AMPW-german for pointing the issue out to me in the first place.

Test images of tooltip change:

Kerbin:
![image](https://github.com/user-attachments/assets/b8b67846-0e59-4ef6-b351-3557f3b101cc)
![image](https://github.com/user-attachments/assets/0f14f196-631a-49ed-86cb-64f9d360ac0c)

Earth:
![image](https://github.com/user-attachments/assets/51a3a5fe-0c4b-4c45-a761-f8ea72f509ba)
![image](https://github.com/user-attachments/assets/c72549e0-9bb4-41d3-9bd1-7dbd5a9b729f)



.dll file is [here](<https://github.com/Clayell/Kerbal-Konstructs/releases/tag/v1.0.0>) if you don't know how to compile it yourself.
